### PR TITLE
Move from github token to deploy key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM ubuntu:15.10
 
-# Install dependent software 
+# Install dependent software
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y curl
-RUN apt-get install -y git 
-RUN apt-get install -y wget 
-RUN apt-get install -y build-essential 
+RUN apt-get install -y git
+RUN apt-get install -y wget
+RUN apt-get install -y build-essential
 RUN apt-get install -y sqlite
-RUN apt-get install -y libsqlite-dev 
-RUN apt-get install -y sqlite3 
-RUN apt-get install -y libsqlite3-dev 
-RUN apt-get install -y libxslt-dev 
-RUN apt-get install -y libxml2-dev 
+RUN apt-get install -y libsqlite-dev
+RUN apt-get install -y sqlite3
+RUN apt-get install -y libsqlite3-dev
+RUN apt-get install -y libxslt-dev
+RUN apt-get install -y libxml2-dev
 RUN apt-get install -y gawk
 RUN apt-get install -y libreadline6-dev
 RUN apt-get install -y zlib1g-dev
@@ -34,6 +34,8 @@ RUN apt-get install -y libpq-dev
 RUN apt-get install -y libgmp-dev
 RUN apt-get install -y libgmp3-dev
 RUN apt-get install -y libmysqlclient-dev
+
+RUN echo "    IdentityFile ~/.ssh/id_rsa" >> /etc/ssh/ssh_config
 
 # Set up pushbit git defaults
 RUN git config --global user.email "bot@pushbit.co"

--- a/clone.sh
+++ b/clone.sh
@@ -1,16 +1,19 @@
 #!/bin/bash -e
 
+# sleep is required otherwise the first log lines here don't end up being recorded
 sleep 3
 
-echo "cloning git repo from:"
-echo https://${GITHUB_TOKEN}@github.com/${GITHUB_USER}/${GITHUB_REPO}.git /pushbit/code
+echo "injecting ssh key"
+mkdir ~/.ssh
+echo ${PUSHBIT_SSH_KEY} > ~/.ssh/id_rsa
 
-git clone https://${GITHUB_TOKEN}@github.com/${GITHUB_USER}/${GITHUB_REPO}.git /pushbit/code
+echo "cloning from ${PUSHBIT_REPOSITORY_URL}"
+git clone ${PUSHBIT_REPOSITORY_URL} /pushbit/code
 
 echo "entering git repo: /pushbit/code"
 cd /pushbit/code
 
-echo "checking out branch/commit: ${BASE_BRANCH}"
-git checkout ${BASE_BRANCH}
+echo "checking out base branch: ${PUSHBIT_BASE_BRANCH}"
+git checkout ${PUSHBIT_BASE_BRANCH}
 
 $1

--- a/clone.sh
+++ b/clone.sh
@@ -3,9 +3,16 @@
 # sleep is required otherwise the first log lines here don't end up being recorded
 sleep 3
 
-echo "injecting ssh key"
 mkdir ~/.ssh
-echo ${PUSHBIT_SSH_KEY} > ~/.ssh/id_rsa
+
+echo "adding github.com to known hosts"
+ssh-keyscan -t dsa github.com >> ~/.ssh/known_hosts
+
+echo "injecting ssh key"
+echo -e "${PUSHBIT_BASE64_SSH_KEY}" | base64 -d > ~/.ssh/id_rsa
+
+echo "setting key permissions"
+chmod 700 ~/.ssh/id_rsa
 
 echo "cloning from ${PUSHBIT_REPOSITORY_URL}"
 git clone ${PUSHBIT_REPOSITORY_URL} /pushbit/code


### PR DESCRIPTION
@awsmsrc I can't remember where we landed on using the branch / commit for checkout - this might need changing?

depends on https://github.com/pushbit-co/platform/pull/64
supercedes https://github.com/pushbit-co/base/pull/3/files
